### PR TITLE
create `incremental` option corresponding to `addSummaryColumns()` in Flint

### DIFF
--- a/man/summarize_avg.Rd
+++ b/man/summarize_avg.Rd
@@ -15,16 +15,16 @@ summarize_avg(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_corr.Rd
+++ b/man/summarize_corr.Rd
@@ -4,7 +4,7 @@
 \alias{summarize_corr}
 \title{Correlation summarizer}
 \usage{
-summarize_corr(ts_rdd, columns, key_columns = list())
+summarize_corr(ts_rdd, columns, key_columns = list(), incremental = FALSE)
 }
 \arguments{
 \item{ts_rdd}{Timeseries RDD being summarized}
@@ -12,13 +12,25 @@ summarize_corr(ts_rdd, columns, key_columns = list())
 \item{columns}{A list of column names}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_corr2.Rd
+++ b/man/summarize_corr2.Rd
@@ -4,7 +4,13 @@
 \alias{summarize_corr2}
 \title{Pairwise correlation summarizer}
 \usage{
-summarize_corr2(ts_rdd, xcolumns, ycolumns, key_columns = list())
+summarize_corr2(
+  ts_rdd,
+  xcolumns,
+  ycolumns,
+  key_columns = list(),
+  incremental = FALSE
+)
 }
 \arguments{
 \item{ts_rdd}{Timeseries RDD being summarized}
@@ -14,13 +20,25 @@ summarize_corr2(ts_rdd, xcolumns, ycolumns, key_columns = list())
 \item{ycolumns}{A list of column names disjoint from xcolumns}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_count.Rd
+++ b/man/summarize_count.Rd
@@ -10,34 +10,34 @@ summarize_count(ts_rdd, column = NULL, window = NULL, key_columns = list())
 \item{ts_rdd}{Timeseries RDD being summarized}
 
 \item{column}{If not NULL, then report the number of values in the column
-specified that are not NULL or NaN within each time window or group of rows
+specified that are not NULL or NaN within each time window or group of records
 with identical timestamps, and store the counts in a new column named
 `<column>_count`.
-Otherwise the number of rows within each time window or group of rows with
+Otherwise the number of records within each time window or group of records with
 identical timestamps is reported, and stored in a column named `count`.}
 
 \item{window}{Either a R expression specifying time windows to be summarized
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
-Count the total number of rows if no column is specified, or the number of
+Count the total number of records if no column is specified, or the number of
 non-null values within the specified column within each time window or within
-each group of rows with identical timestamps
+each group of records with identical timestamps
 }
 \examples{
 

--- a/man/summarize_covar.Rd
+++ b/man/summarize_covar.Rd
@@ -17,23 +17,23 @@ summarize_covar(ts_rdd, xcolumn, ycolumn, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Compute covariance between values from `xcolumn` and `ycolumn` within each time
-window or within each group of rows with identical timestamps, and store results
+window or within each group of records with identical timestamps, and store results
 in a new column named `<xcolumn>_<ycolumn>_covariance`
 }
 \examples{

--- a/man/summarize_dot_product.Rd
+++ b/man/summarize_dot_product.Rd
@@ -23,23 +23,23 @@ summarize_dot_product(
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Compute dot product of values from `xcolumn` and `ycolumn` within a moving
-time window or within each group of rows with identical timestamps and store
+time window or within each group of records with identical timestamps and store
 results in a new column named `<xcolumn>_<ycolumn>_dotProduct`
 }
 \examples{

--- a/man/summarize_ewma.Rd
+++ b/man/summarize_ewma.Rd
@@ -52,13 +52,13 @@ alpha discounts older observations faster}
   https://github.com/twosigma/flint/blob/master/doc/ema.md#legacy).}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \description{
 Compute exponential weighted moving average (EWMA) of `column` and store

--- a/man/summarize_max.Rd
+++ b/man/summarize_max.Rd
@@ -15,23 +15,23 @@ summarize_max(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Find maximum value among values from `column` within each time window or
-within each group of rows with identical timestamps, and store results in a
+within each group of records with identical timestamps, and store results in a
 new column named `<column>_max`
 }
 \examples{

--- a/man/summarize_min.Rd
+++ b/man/summarize_min.Rd
@@ -15,23 +15,23 @@ summarize_min(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Find minimum value among values from `column` within each time window or
-within each group of rows with identical timestamps, and store results in a
+within each group of records with identical timestamps, and store results in a
 new column named `<column>_min`
 }
 \examples{

--- a/man/summarize_nth_central_moment.Rd
+++ b/man/summarize_nth_central_moment.Rd
@@ -4,7 +4,13 @@
 \alias{summarize_nth_central_moment}
 \title{N-th central moment summarizer}
 \usage{
-summarize_nth_central_moment(ts_rdd, column, n, key_columns = list())
+summarize_nth_central_moment(
+  ts_rdd,
+  column,
+  n,
+  key_columns = list(),
+  incremental = FALSE
+)
 }
 \arguments{
 \item{ts_rdd}{Timeseries RDD being summarized}
@@ -14,13 +20,25 @@ summarize_nth_central_moment(ts_rdd, column, n, key_columns = list())
 \item{n}{The order of moment to calculate}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_nth_moment.Rd
+++ b/man/summarize_nth_moment.Rd
@@ -4,7 +4,13 @@
 \alias{summarize_nth_moment}
 \title{N-th moment summarizer}
 \usage{
-summarize_nth_moment(ts_rdd, column, n, key_columns = list())
+summarize_nth_moment(
+  ts_rdd,
+  column,
+  n,
+  key_columns = list(),
+  incremental = FALSE
+)
 }
 \arguments{
 \item{ts_rdd}{Timeseries RDD being summarized}
@@ -14,13 +20,25 @@ summarize_nth_moment(ts_rdd, column, n, key_columns = list())
 \item{n}{The order of moment to calculate}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_product.Rd
+++ b/man/summarize_product.Rd
@@ -15,16 +15,16 @@ summarize_product(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_quantile.Rd
+++ b/man/summarize_quantile.Rd
@@ -17,23 +17,23 @@ summarize_quantile(ts_rdd, column, p, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Compute quantiles of `column` within each time window or within each group of
-rows with identical time-stamps, and store results in new columns named
+records with identical time-stamps, and store results in new columns named
 `<column>_<quantile value>quantile`
 }
 \examples{

--- a/man/summarize_stddev.Rd
+++ b/man/summarize_stddev.Rd
@@ -15,16 +15,16 @@ summarize_stddev(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
@@ -32,7 +32,7 @@ A TimeSeriesRDD containing the summarized result
 \description{
 Compute unbiased (i.e., Bessel's correction is applied) sample standard
 deviation of values from `column` within each time window or within each
-group of rows with identical timestamps, and store results in a new column
+group of records with identical timestamps, and store results in a new column
 named `<column>_stddev`
 }
 \examples{

--- a/man/summarize_sum.Rd
+++ b/man/summarize_sum.Rd
@@ -15,16 +15,16 @@ summarize_sum(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_var.Rd
+++ b/man/summarize_var.Rd
@@ -15,23 +15,23 @@ summarize_var(ts_rdd, column, window = NULL, key_columns = list())
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Compute variance of values from `column` within each time window or within
-each group of rows with identical timestamps, and store results in a new column
+each group of records with identical timestamps, and store results in a new column
 named `<column>_variance`, with Bessel's correction applied to the results
 }
 \examples{

--- a/man/summarize_weighted_avg.Rd
+++ b/man/summarize_weighted_avg.Rd
@@ -23,16 +23,16 @@ summarize_weighted_avg(
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_weighted_corr.Rd
+++ b/man/summarize_weighted_corr.Rd
@@ -9,7 +9,8 @@ summarize_weighted_corr(
   xcolumn,
   ycolumn,
   weight_column,
-  key_columns = list()
+  key_columns = list(),
+  incremental = FALSE
 )
 }
 \arguments{
@@ -22,13 +23,25 @@ summarize_weighted_corr(
 \item{weight_column}{Column specifying relative weight of each data point}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result

--- a/man/summarize_weighted_covar.Rd
+++ b/man/summarize_weighted_covar.Rd
@@ -26,23 +26,23 @@ summarize_weighted_covar(
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
 Compute unbiased weighted covariance between values from `xcolumn` and
-`ycolumn` within each time window or within each group of rows with identical
+`ycolumn` within each time window or within each group of records with identical
 timestamps, using values from `weight_column` as relative weights, and store
 results in a new column named
 `<xcolumn>_<ycolumn>_<weight_column>_weightedCovariance`

--- a/man/summarize_z_score.Rd
+++ b/man/summarize_z_score.Rd
@@ -8,7 +8,8 @@ summarize_z_score(
   ts_rdd,
   column,
   include_current_observation = FALSE,
-  key_columns = list()
+  key_columns = list(),
+  incremental = FALSE
 )
 }
 \arguments{
@@ -21,22 +22,34 @@ deviation with current observation in z-score calculation, otherwise use
 unbiased sample standard deviation excluding current observation}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \value{
 A TimeSeriesRDD containing the summarized result
 }
 \description{
-Compute z-score of the most recent value in the column specified, with
-respect to the sample mean and standard deviation observed so far, with the
-option for out-of-sample calculation, and store result in a new column named
-`<column>_zScore`
+Compute z-score of value(s) in the column specified, with respect to the
+sample mean and standard deviation observed so far, with the option for out-
+of-sample calculation, and store result in a new column named
+`<column>_zScore`.
 }
 \examples{
 

--- a/man/summarizers.Rd
+++ b/man/summarizers.Rd
@@ -10,18 +10,30 @@
 (e.g., `in_past("1h")` to summarize data from looking behind 1 hour at
 each time point, `in_future("5s")` to summarize data from looking forward
 5 seconds at each time point), or `NULL` to compute aggregate statistics
-on rows grouped by timestamps}
+on records grouped by timestamps}
 
 \item{column}{Column to be summarized}
 
 \item{key_columns}{Optional list of columns that will form an equivalence
-relation associating each row with the time series it belongs to (i.e., any
-2 rows having equal values in those columns will be associated with the
-same time series, and any 2 rows having differing values in those columns
-are considered to be from 2 separate time series and will therefore be
-summarized separately)
-By default, `key_colums` is empty and all rows are considered to be part of
-a single time series.}
+relation associating each record with the time series it belongs to (i.e.,
+any 2 records having equal values in those columns will be associated with
+the same time series, and any 2 records having differing values in those
+columns are considered to be from 2 separate time series and will therefore
+be summarized separately)
+By default, `key_colums` is empty and all records are considered to be part
+of a single time series.}
+
+\item{incremental}{If FALSE and `key_columns` is empty, then apply the
+summarizer to all records of `ts_rdd`.
+If FALSE and `key_columns` is non-empty, then apply the summarizer to all
+records within each group determined by `key_columns`.
+If TRUE and `key_columns` is empty, then for each record in `ts_rdd`,
+the summarizer is applied to that record and all records preceding it, and
+the summarized result is associated with the timestamp of that record.
+If TRUE and `key_columns` is non-empty, then for each record within a group
+of records determined by 1 or more key columns, the summarizer is applied
+to that record and all records preceding it within its group, and the
+summarized result is associated with the timestamp of that record.}
 }
 \description{
 R wrapper functions for commonly used Flint summarizer functionalities such as

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -160,20 +160,6 @@ testthat_corr_test_case <- function() {
   )
 }
 
-testthat_weighted_corr_test_case <- function() {
-  testthat_sdf(
-    function() {
-      tibble::tibble(
-        t = 1000 + 100 * c(1, seq(8)),
-        w = seq(9, 1, -1),
-        x = seq(9),
-        y = seq(9, 1, -1)
-      )
-    },
-    ".testthat_weighted_corr_test_case"
-  )
-}
-
 testthat_multiple_simple_ts_test_case <- function() {
   testthat_sdf(
     function() {


### PR DESCRIPTION
For use cases similar to EWMA where some summary statistics needs to be computed at each time stamp using all data points occurred at or before that time, so that one can see how that summary statistics changes over time.

Signed-off-by: Yitao Li <yitao@rstudio.com>